### PR TITLE
fix map height

### DIFF
--- a/src/components/interfaces/PositionSensor.vue
+++ b/src/components/interfaces/PositionSensor.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card :style="{ height: '100%', width: '100%' }">
+  <v-card :style="{ height: '300px', width: '100%' }">
     <l-map ref="map" :zoom="zoom()" :center="position<PointExpression>()"
       :options="{
         zoomControl: false,


### PR DESCRIPTION
Looks like setting a fixed height makes things happier...

Seems like the percentage-based height has some race condition where leaflet doesn't register that the window grew bigger