### PR TITLE
plugin-installer: make description optional

### DIFF
--- a/src/components/plugin/InstallPlugin.vue
+++ b/src/components/plugin/InstallPlugin.vue
@@ -100,7 +100,7 @@ const plugins = asyncComputed({
     const response = await fetch(url);
     const json = await response.json();
     return json.objects.map((o: any) => ({
-      description: o.package.description.replace(' for Scrypted', ''),
+      description: o.package.description?.replace(' for Scrypted', ''),
       name: o.package.name,
       version: o.package.version,
       username: o.package.publisher.username,


### PR DESCRIPTION
A missing description will break any search that includes the plugin.