### PR TITLE
TTYService: redraw when device changes

### DIFF
--- a/src/components/Device.vue
+++ b/src/components/Device.vue
@@ -155,7 +155,7 @@
             </template>
           </Camera>
           <PtyComponent v-if="hasTTYService" :reconnect="true" title="TTY Interface" :expand-button="true"
-            :hello="(device.nativeId || 'undefined')" :control="true" :pluginId="device.pluginId" :nativeId="device.nativeId" class="mb-4">
+            :control="true" :pluginId="device.pluginId" :nativeId="device.nativeId" class="mb-4">
           </PtyComponent>
 
           <DeviceProvider v-if="hasDeviceCreator" class="mb-4" :id="id"></DeviceProvider>

--- a/src/components/Device.vue
+++ b/src/components/Device.vue
@@ -155,7 +155,7 @@
             </template>
           </Camera>
           <PtyComponent v-if="hasTTYService" :reconnect="true" title="TTY Interface" :expand-button="true"
-            :control="true" :pluginId="device.pluginId" :nativeId="device.nativeId" class="mb-4">
+            :hello="(device.nativeId || 'undefined')" :control="true" :pluginId="device.pluginId" :nativeId="device.nativeId" class="mb-4">
           </PtyComponent>
 
           <DeviceProvider v-if="hasDeviceCreator" class="mb-4" :id="id"></DeviceProvider>

--- a/src/components/PtyComponent.vue
+++ b/src/components/PtyComponent.vue
@@ -119,12 +119,16 @@ unmounted.promise.then(() => {
 
 let localQueue: ReturnType<typeof createAsyncQueueFromGenerator>;
 
-watch(() => props.hello, () => {
+function refreshOnUpdate() {
   localQueue?.end();
   localQueue = undefined;
   if (!props.reconnect)
     connectPty();
-});
+}
+
+watch(() => props.hello, refreshOnUpdate);
+watch(() => props.pluginId, refreshOnUpdate);
+watch(() => props.nativeId, refreshOnUpdate);
 
 async function connectPty() {
   buffer = [];


### PR DESCRIPTION
When changing from one TTYService to another (e.g. a plugin implements TTY, as well as a child device, and the user clicks into the child device), the PtyComponent needs gentle nudging for it to reconnect to the new device. This still has about 1 second delay before it reconnects, but at least it does so instead of staying on the previous TTY.