### PR TITLE
OauthClient: fix default hostname selection

### DIFF
--- a/src/components/interfaces/OauthClient.vue
+++ b/src/components/interfaces/OauthClient.vue
@@ -29,7 +29,7 @@
 </template>
 <script setup lang="ts">
 import { isInstalledApp } from '@/common/browser';
-import { connectedClient } from '@/common/client';
+import { connectedClient, getBaseHostname, isAppDomain } from '@/common/client';
 import { getFaPrefix } from '@/util/device-icons';
 import { getDeviceFromId } from '@/util/id-device';
 import { OauthClient } from '@scrypted/types';
@@ -72,7 +72,7 @@ async function login() {
       u.hostname = 'localhost';
     }
     if (u.hostname === 'localhost') {
-      u.hostname = new URL(window.location.href).hostname;
+      u.hostname = isAppDomain() ? getBaseHostname() : new URL(window.location.href).hostname;
       redirect_uri = u.toString();
     }
   }


### PR DESCRIPTION
Previously the OauthClient flow will inject the current window href's hostname into the redirect_uri if not explicitly defined by the plugin, which is typically useful for having the oauth flow redirect a token back to the plugin. However, for static cloud sites (manage.scrypted.app) which rely on scrypted-client to make API-only connections to the server's publicly accessible endpoint (whether self-hosted or proxied via home.scrypted.app), selecting manage.scrypted.app as the hostname will not work since the requested callback endpoint does not exist.

This change fixes the issue by selecting a cloud-accessible hostname when running as a cloud endpoint, and falling back to the previous behavior on direct connection.